### PR TITLE
Revert Firebase URL

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -14,8 +14,8 @@ angular.module('firePokerApp')
 
     // Firebase URL
     //var URL = 'https://pzfqrq7kjy.firebaseio.com';
-    //var URL = 'https://firepokerio.firebaseio.com';
-    var URL = 'https://firepoker-75089.firebaseio.com';
+    var URL = 'https://firepokerio.firebaseio.com';
+    // var URL = 'https://firepoker-75089.firebaseio.com';
 
     // Initialize Firebase
     /*global Firebase*/


### PR DESCRIPTION
I had come across the same issue of https://github.com/Wizehive/Firepoker/issues/59 , and tried to figure out the cause of it in my local environment.

Finally I've found that reverting the Firebase URL to the previous one solves the problem.

---

But I don't know the reason why you changed the Firebase URL.

So if you think the latest URL should be used, it's OK to reject this pull request. In that case, would you please fix the Firebase instance referred by the URL?
