### PR TITLE
update wikipedia link for Anchoring

### DIFF
--- a/app/views/games/index.html
+++ b/app/views/games/index.html
@@ -14,7 +14,7 @@
     cards face-down to the table, instead of speaking them aloud. The cards are
     revealed, and the estimates are then discussed. By hiding the figures in
     this way, the group can avoid the cognitive bias of
-    <a href="https://en.wikipedia.org/wiki/Anchoring" title="Anchoring" target="_blank">anchoring</a>, where the first
+    <a href="https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)" title="Anchoring" target="_blank">anchoring</a>, where the first
     number spoken aloud sets a precedent for subsequent estimates.
     </p>
     <p>To read more, check out the <a href="https://en.wikipedia.org/wiki/Planning_poker" target="_blank">Wikipedia</a> page.</p>


### PR DESCRIPTION
Wikipedia now redirects "Anchoring" to "Anchor", so updating our href to the wiki for Cognitive Bias Anchoring.